### PR TITLE
Set width of volume bar

### DIFF
--- a/translationRecorder/app/build.gradle
+++ b/translationRecorder/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "org.wycliffeassociates.translationrecorder"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 14
-        versionName "1.3.1-rc"
+        versionCode 15
+        versionName "1.3.2-rc"
         versionNameSuffix
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/translationRecorder/app/src/main/res/layout/activity_recording_screen.xml
+++ b/translationRecorder/app/src/main/res/layout/activity_recording_screen.xml
@@ -30,9 +30,8 @@
 
         <FrameLayout
             android:id="@+id/fragment_volume_bar_holder"
-            android:layout_width="0dp"
+            android:layout_width="24dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             />
 
 


### PR DESCRIPTION
the waveform was getting 90% of the width, and 10% for volume (as the layout implied). Perhaps this wasn't working right with the support library, but changed with androidx update?

Either way, this seems to get it back to how things were looking before.